### PR TITLE
Add overload to specify callback in Transition.Delay

### DIFF
--- a/IntelliFactory.WebSharper.D3/Main.fs
+++ b/IntelliFactory.WebSharper.D3/Main.fs
@@ -180,6 +180,7 @@ module Definition =
         ChainedClass "Transition" Transition <| fun chained ->
         [
             "delay"      => chained Int?delay
+            "delay"      => chained (Obj * Int ^-> Int)?delayFn
             "duration"   => chained Int?duration
             "ease"       => chained (!+Float * String?value) + chained easing?value
             "attr"       => chained (nameArg * (Obj + selectionCallback Obj)?value)


### PR DESCRIPTION
Addresses #14.

Adds an overload to allow the user to specify a callback function in Transition.Delay, so that the delays for individual sub-transitions may be specified.
